### PR TITLE
(Mu2e/Offline) remove code checks from default tests

### DIFF
--- a/repos/Mu2e/Offline/test_suites.py
+++ b/repos/Mu2e/Offline/test_suites.py
@@ -35,7 +35,7 @@ REGEX_CUSTOM_TEST_MU2E_PR = re.compile(TEST_REGEXP_CUSTOM_TEST_TRIGGER, re.I | r
 
 
 SUPPORTED_TESTS = ['build', 'code checks', 'validation']
-DEFAULT_TESTS = ['build', 'code checks']
+DEFAULT_TESTS = ['build']
 
 
 TEST_ALIASES = {


### PR DESCRIPTION
Code checks are disabled for now on Mu2e/Offline