### PR TITLE
Make regex less strict

### DIFF
--- a/repos/Mu2e/Offline/process_pr.py
+++ b/repos/Mu2e/Offline/process_pr.py
@@ -22,7 +22,7 @@ which require these tests: {tests_required}.
 {watchers}
 {tests_triggered_msg}
 
-<a href="https://mu2ewiki.fnal.gov/wiki/Git#github_pull_request_procedures">cms-bot/mu2e commands are explained here</a>
+<a href="https://mu2ewiki.fnal.gov/wiki/Git#GitHub_Pull_Request_Procedures_and_FNALbuild">FNALbuild is explained here.</a>
 """
 
 TESTS_TRIGGERED_CONFIRMATION = """:hourglass: The following tests have been triggered for ref {commit_link}: {test_list} {tests_already_running_msg}"""

--- a/repos/Mu2e/Offline/test_suites.py
+++ b/repos/Mu2e/Offline/test_suites.py
@@ -10,21 +10,21 @@ REGEX_DEFTEST_MU2E_PR = re.compile(TEST_REGEXP_MU2E_DEFTEST_TRIGGER, re.I | re.M
 
 # build test
 TEST_REGEXP_MU2E_BUILDTEST_TRIGGER = (
-    "(@%s)(\s*[,:;]*\s+|\s+)(please\s*[,]*\s+|)(run\s+(build\s*)test(s|)|(test\s+(build)))(\.|$)"
+    "(@%s)(\s*[,:;]*\s+|\s+)(please\s*[,]*\s+|)(run\s+(build\s*)test(s|)|(test\s+(build)))"
     % MU2E_BOT_USER
 )
 REGEX_BUILDTEST_MU2E_PR = re.compile(TEST_REGEXP_MU2E_BUILDTEST_TRIGGER, re.I | re.M)
 
 # code test
 TEST_REGEXP_MU2E_LINTTEST_TRIGGER = (
-    "(@%s)(\s*[,:;]*\s+|\s+)(please\s*[,]*\s+|)(run\s+(code\s*)(test(s|)|check(s)|lint(er|ing))|(test\s+code|check\s+code))(\.|$)"
+    "(@%s)(\s*[,:;]*\s+|\s+)(please\s*[,]*\s+|)(run\s+(code\s*)(test(s|)|check(s|)))"
     % MU2E_BOT_USER
 )
 REGEX_LINTTEST_MU2E_PR = re.compile(TEST_REGEXP_MU2E_LINTTEST_TRIGGER, re.I | re.M)
 
 # physics validation
 TEST_REGEXP_MU2E_VALIDATION_TRIGGER = (
-    "(@%s)(\s*[,:;]*\s+|\s+)(please\s*[,]*\s+|)(run\s+(V|v)alidation)(\.|$)" % MU2E_BOT_USER
+    "(@%s)(\s*[,:;]*\s+|\s+)(please\s*[,]*\s+|)(run\s+validation)" % MU2E_BOT_USER
 )
 REGEX_VALIDATIONTEST_MU2E_PR = re.compile(TEST_REGEXP_MU2E_VALIDATION_TRIGGER, re.I | re.M)
 


### PR DESCRIPTION
Stops FNALbuild ignoring messages of the form '@FNALbuild run build test\r\n'