### PR TITLE
(Mu2e) Support PR base branches other than master

### DIFF
--- a/repos/Mu2e/Offline/process_pr.py
+++ b/repos/Mu2e/Offline/process_pr.py
@@ -191,7 +191,7 @@ def process_pr(repo_config, gh, repo, issue, dryRun, cmsbuild_user=None, force=F
 
     # this will be the commit of master that the PR is merged
     # into for the CI tests (for a build test this is just the current HEAD.)
-    master_commit_sha = repo.get_branch("master").commit.sha
+    master_commit_sha = pr.base.sha # repo.get_branch("master").commit.sha
 
     # get latest commit
     last_commit = pr.get_commits().reversed[0]
@@ -209,6 +209,7 @@ def process_pr(repo_config, gh, repo, issue, dryRun, cmsbuild_user=None, force=F
 
     print("Latest commit message: ", git_commit.message.encode("ascii", "ignore"))
     print("Latest commit sha: ", git_commit.sha)
+    print("Merging into: ",pr.base.ref, pr.base.sha)
     print("PR update time", pr.updated_at)
     print("Time UTC:", datetime.utcnow())
 


### PR DESCRIPTION
supports CI tests for the Mu2eII_SM21 branch (see Mu2e/Offline#224)

uses `pr.base.sha` rather than `repo.get_branch("master").commit.sha`